### PR TITLE
Change scheduling policy for Java threads

### DIFF
--- a/src/hotspot/share/gc/shared/concurrentGCThread.cpp
+++ b/src/hotspot/share/gc/shared/concurrentGCThread.cpp
@@ -35,7 +35,7 @@ ConcurrentGCThread::ConcurrentGCThread() :
     _has_terminated(false) {}
 
 void ConcurrentGCThread::create_and_start(ThreadPriority prio) {
-  if (os::create_thread(this, os::cgc_thread)) {
+  if (os::create_thread(this, os::cgc_thread, false)) {
     os::set_priority(this, prio);
     os::start_thread(this);
   }

--- a/src/hotspot/share/gc/shared/workerManager.hpp
+++ b/src/hotspot/share/gc/shared/workerManager.hpp
@@ -78,7 +78,7 @@ uint WorkerManager::add_workers(WorkGang* workers,
     if (initializing || !InjectGCWorkerCreationFailure) {
       new_worker = workers->install_worker(worker_id);
     }
-    if (new_worker == NULL || !os::create_thread(new_worker, worker_type)) {
+    if (new_worker == NULL || !os::create_thread(new_worker, worker_type, false)) {
       log_trace(gc, task)("WorkerManager::add_workers() : "
                           "creation failed due to failed allocation of native %s",
                           new_worker == NULL ? "memory" : "thread");

--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -438,7 +438,7 @@ JavaThread* JfrThreadSampler::next_thread(ThreadsList* t_list, JavaThread* first
 }
 
 void JfrThreadSampler::start_thread() {
-  if (os::create_thread(this, os::os_thread)) {
+  if (os::create_thread(this, os::os_thread, false)) {
     os::start_thread(this);
   } else {
     log_error(jfr)("Failed to create thread for thread sampling");

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -80,7 +80,7 @@ AsyncLogWriter::AsyncLogWriter()
   : _flush_sem(0), _lock(), _data_available(false),
     _initialized(false),
     _stats(17 /*table_size*/) {
-  if (os::create_thread(this, os::asynclog_thread)) {
+  if (os::create_thread(this, os::asynclog_thread, false)) {
     _initialized = true;
   } else {
     log_warning(logging, thread)("AsyncLogging failed to create thread. Falling back to synchronous logging.");

--- a/src/hotspot/share/runtime/nonJavaThread.cpp
+++ b/src/hotspot/share/runtime/nonJavaThread.cpp
@@ -160,7 +160,7 @@ volatile bool  WatcherThread::_should_terminate = false;
 
 WatcherThread::WatcherThread() : NonJavaThread() {
   assert(watcher_thread() == NULL, "we can only allocate one WatcherThread");
-  if (os::create_thread(this, os::watcher_thread)) {
+  if (os::create_thread(this, os::watcher_thread, false)) {
     _watcher_thread = this;
 
     // Set the watcher thread to the highest OS priority which should not be

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -456,7 +456,7 @@ class os: AllStatic {
 
   static bool create_thread(Thread* thread,
                             ThreadType thr_type,
-                            size_t req_stack_size = 0);
+                            bool is_java_thread, size_t req_stack_size = 0);
 
   // The "main thread", also known as "starting thread", is the thread
   // that loads/creates the JVM via JNI_CreateJavaVM.

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1201,7 +1201,7 @@ JavaThread::JavaThread(ThreadFunction entry_point, size_t stack_sz) : JavaThread
   os::ThreadType thr_type = os::java_thread;
   thr_type = entry_point == &CompilerThread::thread_entry ? os::compiler_thread :
                                                             os::java_thread;
-  os::create_thread(this, thr_type, stack_sz);
+  os::create_thread(this, thr_type, true, stack_sz);
   // The _osthread may be NULL here because we ran out of memory (too many threads active).
   // We need to throw and OutOfMemoryError - however we cannot do this here because the caller
   // may hold a lock and all locks must be unlocked before throwing the exception (throwing
@@ -2902,7 +2902,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
     VMThread::create();
     Thread* vmthread = VMThread::vm_thread();
 
-    if (!os::create_thread(vmthread, os::vm_thread)) {
+    if (!os::create_thread(vmthread, os::vm_thread, false)) {
       vm_exit_during_initialization("Cannot create VM thread. "
                                     "Out of system resources.");
     }


### PR DESCRIPTION
This PR changes scheduling policies for Java threads only. An additional flag is added to a method that creates all the threads in the OpenJDK. By changing the flag from false to true, we can change the scheduling policy for any group of threads.